### PR TITLE
chore: remove prettier to use eslint-config-cozy-app's

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,0 @@
-build
-node_modules
-package.json
-

--- a/package.json
+++ b/package.json
@@ -18,16 +18,11 @@
   "eslintIgnore": [
     "build"
   ],
-  "prettier": {
-    "semi": false,
-    "singleQuote": true
-  },
   "scripts": {
     "start": "node ./src/index.js",
     "dev": "cozy-konnector-dev build/index.js",
     "standalone": "cozy-konnector-standalone build/index.js",
     "build": "webpack",
-    "format": "prettier --write '**/*.{js,json}'",
     "precommit": "yarn lint",
     "lint": "eslint --fix .",
     "deploy": "git-directory-deploy --directory build/ --branch build --repo=${DEPLOY_REPOSITORY:-https://$GITHUB_TOKEN@github.com/konnectors/cozy-konnector-nef.git}",
@@ -46,7 +41,6 @@
     "eslint-config-cozy-app": "0.5.1",
     "git-directory-deploy": "1.5.1",
     "husky": "0.14.3",
-    "prettier": "1.11.1",
     "webpack": "4.2.0",
     "webpack-cli": "2.0.13"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5937,7 +5937,7 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@1.11.1, prettier@^1.11.1, prettier@^1.5.3:
+prettier@^1.11.1, prettier@^1.5.3:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.11.1.tgz#61e43fc4cd44e68f2b0dfc2c38cd4bb0fccdcc75"
 


### PR DESCRIPTION
Since we now use eslint-config-cozy-app@0.5.1, it embeds prettier, so we don't need `format` script, direct dependency to prettier and `.prettierignore` file